### PR TITLE
Fix consumption issues and add warnings when misused

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,11 @@ buildscript {
 		maven { url "https://jitpack.io" }
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:2.2.0-alpha3'
+		classpath 'com.android.tools.build:gradle:2.2.0-alpha5'
 		classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4'
 		classpath 'me.tatarka:gradle-retrolambda:3.2.5'
 		classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'
+		classpath 'com.google.guava:guava:19.0'
 	}
 
 	configurations.classpath.exclude group: 'com.android.tools.external.lombok'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -10,7 +10,7 @@ android {
 		minSdkVersion 16
 		targetSdkVersion 24
 		versionCode 1
-		versionName "1.1"
+		versionName "1.2"
 		consumerProguardFiles 'proguard-rules.pro'
 	}
 

--- a/lib/src/main/java/com/busybusy/dbc/Dbc.java
+++ b/lib/src/main/java/com/busybusy/dbc/Dbc.java
@@ -16,6 +16,8 @@
 
 package com.busybusy.dbc;
 
+import android.support.annotation.CheckResult;
+
 import com.busybusy.dbc.conditions.BooleanCondition;
 import com.busybusy.dbc.conditions.DoubleCondition;
 import com.busybusy.dbc.conditions.FloatCondition;
@@ -41,136 +43,163 @@ public class Dbc
 {
 	private Dbc() {}
 
-	public static <T> ObjectCondition require(T subject)
+	@CheckResult
+	public static <T> ObjectCondition<T> require(T subject)
 	{
-		return new ObjectCondition(subject);
+		return new ObjectCondition<>(subject);
 	}
 
+	@CheckResult
 	public static BooleanCondition require(Boolean subject)
 	{
 		return new BooleanCondition(subject);
 	}
 
+	@CheckResult
 	public static DoubleCondition require(Double subject)
 	{
 		return new DoubleCondition(subject);
 	}
 
+	@CheckResult
 	public static FloatCondition require(Float subject)
 	{
 		return new FloatCondition(subject);
 	}
 
+	@CheckResult
 	public static IntegralCondition<Integer> require(Integer subject)
 	{
 		return new IntegralCondition<>(subject);
 	}
 
+	@CheckResult
 	public static IntegralCondition<Long> require(Long subject)
 	{
 		return new IntegralCondition<>(subject);
 	}
 
+	@CheckResult
 	public static <T extends List<E>, E> ListCondition<T, E> require(T subject)
 	{
 		return new ListCondition<>(subject);
 	}
 
+	@CheckResult
 	public static <T extends Map<K, V>, K, V> MapCondition<T, K, V> require(T subject)
 	{
 		return new MapCondition<>(subject);
 	}
 
+	@CheckResult
 	public static StringCondition require(String subject)
 	{
 		return new StringCondition(subject);
 	}
 
+	@CheckResult
 	public static <T> ObjectCondition check(T subject)
 	{
-		return new ObjectCondition(subject);
+		return new ObjectCondition<>(subject);
 	}
 
+	@CheckResult
 	public static BooleanCondition check(Boolean subject)
 	{
 		return new BooleanCondition(subject);
 	}
 
+	@CheckResult
 	public static DoubleCondition check(Double subject)
 	{
 		return new DoubleCondition(subject);
 	}
 
+	@CheckResult
 	public static FloatCondition check(Float subject)
 	{
 		return new FloatCondition(subject);
 	}
 
+	@CheckResult
 	public static IntegralCondition<Integer> check(Integer subject)
 	{
 		return new IntegralCondition<>(subject);
 	}
 
+	@CheckResult
 	public static IntegralCondition<Long> check(Long subject)
 	{
 		return new IntegralCondition<>(subject);
 	}
 
+	@CheckResult
 	public static <T extends List<E>, E> ListCondition<T, E> check(T subject)
 	{
 		return new ListCondition<>(subject);
 	}
 
+	@CheckResult
 	public static <T extends Map<K, V>, K, V> MapCondition<T, K, V> check(T subject)
 	{
 		return new MapCondition<>(subject);
 	}
 
+	@CheckResult
 	public static StringCondition check(String subject)
 	{
 		return new StringCondition(subject);
 	}
 
+	@CheckResult
 	public static <T> ObjectCondition ensure(T subject)
 	{
-		return new ObjectCondition(subject);
+		return new ObjectCondition<>(subject);
 	}
 
+	@CheckResult
 	public static BooleanCondition ensure(Boolean subject)
 	{
 		return new BooleanCondition(subject);
 	}
 
+	@CheckResult
 	public static DoubleCondition ensure(Double subject)
 	{
 		return new DoubleCondition(subject);
 	}
 
+	@CheckResult
 	public static FloatCondition ensure(Float subject)
 	{
 		return new FloatCondition(subject);
 	}
 
+	@CheckResult
 	public static IntegralCondition<Integer> ensure(Integer subject)
 	{
 		return new IntegralCondition<>(subject);
 	}
 
+	@CheckResult
 	public static IntegralCondition<Long> ensure(Long subject)
 	{
 		return new IntegralCondition<>(subject);
 	}
 
+	@CheckResult
 	public static <T extends List<E>, E> ListCondition<T, E> ensure(T subject)
 	{
 		return new ListCondition<>(subject);
 	}
 
+	@CheckResult
 	public static <T extends Map<K, V>, K, V> MapCondition<T, K, V> ensure(T subject)
 	{
 		return new MapCondition<>(subject);
 	}
 
+	@CheckResult
 	public static StringCondition ensure(String subject)
 	{
 		return new StringCondition(subject);

--- a/lib/src/main/java/com/busybusy/dbc/Dbc.java
+++ b/lib/src/main/java/com/busybusy/dbc/Dbc.java
@@ -98,7 +98,7 @@ public class Dbc
 	}
 
 	@CheckResult
-	public static <T> ObjectCondition check(T subject)
+	public static <T> ObjectCondition<T> check(T subject)
 	{
 		return new ObjectCondition<>(subject);
 	}
@@ -152,7 +152,7 @@ public class Dbc
 	}
 
 	@CheckResult
-	public static <T> ObjectCondition ensure(T subject)
+	public static <T> ObjectCondition<T> ensure(T subject)
 	{
 		return new ObjectCondition<>(subject);
 	}

--- a/lib/src/main/java/com/busybusy/dbc/checks/BasicChecks.java
+++ b/lib/src/main/java/com/busybusy/dbc/checks/BasicChecks.java
@@ -16,6 +16,7 @@
 
 package com.busybusy.dbc.checks;
 
+import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 
 import java.util.Comparator;
@@ -33,6 +34,7 @@ public interface BasicChecks<T, Self extends BasicChecks<T, Self>> extends NullC
 	 *
 	 * @param message Message to use if the next check fails
 	 */
+	@CheckResult
 	Self message(@NonNull String message);
 
 	/**
@@ -40,6 +42,7 @@ public interface BasicChecks<T, Self extends BasicChecks<T, Self>> extends NullC
 	 *
 	 * @param lazyMessage A callable setup to produce a message if the next check fails
 	 */
+	@CheckResult
 	Self message(@NonNull Callable<String> lazyMessage);
 
 	/**

--- a/lib/src/main/java/com/busybusy/dbc/conditions/BasicCondition.java
+++ b/lib/src/main/java/com/busybusy/dbc/conditions/BasicCondition.java
@@ -16,6 +16,7 @@
 
 package com.busybusy.dbc.conditions;
 
+import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 
 import com.busybusy.dbc.DbcAssertionError;
@@ -49,6 +50,7 @@ public abstract class BasicCondition<T, Self extends BasicCondition<T, Self>> im
 	/**
 	 * {@inheritDoc}
 	 */
+	@CheckResult
 	@Override
 	public Self message(@NonNull String message)
 	{
@@ -63,6 +65,7 @@ public abstract class BasicCondition<T, Self extends BasicCondition<T, Self>> im
 	/**
 	 * {@inheritDoc}
 	 */
+	@CheckResult
 	@Override
 	public Self message(@NonNull Callable<String> lazyMessage)
 	{

--- a/lib/src/main/java/com/busybusy/dbc/conditions/ObjectCondition.java
+++ b/lib/src/main/java/com/busybusy/dbc/conditions/ObjectCondition.java
@@ -21,7 +21,7 @@ package com.busybusy.dbc.conditions;
  *
  * @author Trevor
  */
-public final class ObjectCondition extends BasicCondition<Object, ObjectCondition>
+public final class ObjectCondition<T> extends BasicCondition<T, ObjectCondition<T>>
 {
-	public ObjectCondition(Object subject) { super(subject); }
+	public ObjectCondition(T subject) { super(subject); }
 }

--- a/lib/src/test/java/com/busybusy/dbc/conditions/ObjectConditionTest.java
+++ b/lib/src/test/java/com/busybusy/dbc/conditions/ObjectConditionTest.java
@@ -33,10 +33,10 @@ public class ObjectConditionTest
 	@Test
 	public void isNull_enabled() throws Exception
 	{
-		ObjectCondition nullCondition = new ObjectCondition(null);
+		ObjectCondition<Object> nullCondition = new ObjectCondition<>(null);
 		nullCondition.isNull();
 
-		ObjectCondition nonNullCondition = new ObjectCondition(new Object());
+		ObjectCondition<Object> nonNullCondition = new ObjectCondition<>(new Object());
 
 		assertThatThrownBy(nonNullCondition::isNull)
 				.isInstanceOf(DbcAssertionError.class)
@@ -46,10 +46,10 @@ public class ObjectConditionTest
 	@Test
 	public void isNotNull_enabled() throws Exception
 	{
-		ObjectCondition nonNullCondition = new ObjectCondition(new Object());
+		ObjectCondition<Object> nonNullCondition = new ObjectCondition<>(new Object());
 		nonNullCondition.isNotNull();
 
-		ObjectCondition nullCondition = new ObjectCondition(null);
+		ObjectCondition<Object> nullCondition = new ObjectCondition<>(null);
 
 		assertThatThrownBy(nullCondition::isNotNull)
 				.isInstanceOf(DbcAssertionError.class)
@@ -59,7 +59,7 @@ public class ObjectConditionTest
 	@Test
 	public void passes_enabled() throws Exception
 	{
-		ObjectCondition condition = new ObjectCondition(new Object());
+		ObjectCondition<Object> condition = new ObjectCondition<>(new Object());
 		condition.passes(subject -> true);
 
 		assertThatThrownBy(() -> condition.passes(subject -> false))
@@ -70,8 +70,13 @@ public class ObjectConditionTest
 	@Test
 	public void isEqualTo_enabled() throws Exception
 	{
-		ObjectCondition condition = new ObjectCondition(2);
-		condition.isEqualTo(2);
+		ObjectCondition<Integer> condition = new ObjectCondition<>(2)
+				.message("Checking that the generics signatures are correct")
+				.passes(subject -> {
+					long value = subject.longValue();
+					return true;
+				})
+				.isEqualTo(2);
 
 		assertThatThrownBy(() -> condition.isEqualTo(3))
 				.isInstanceOf(DbcAssertionError.class)
@@ -81,7 +86,7 @@ public class ObjectConditionTest
 	@Test
 	public void isEqualToCustomComparator_enabled() throws Exception
 	{
-		ObjectCondition condition = new ObjectCondition(2);
+		ObjectCondition<Integer> condition = new ObjectCondition<>(2);
 		condition.isEqualTo(2, (integer, t1) -> 0);
 
 		assertThatThrownBy(() -> condition.isEqualTo(2, (integer, t1) -> 1))


### PR DESCRIPTION
This makes the base type of `ObjectCondition` generic thus allowing inherited methods to behave correctly. (most effected is the `passes(DbcBlock)` method).

This also adds the `@CheckResult` support annotation to certain methods thus warning the user of probable usage errors.

Version 1.2.0 should be ready after merging. Minor version number bump being justified by two "half" features.